### PR TITLE
index.js: limit <Link> to only wrap around the h3 header in post-list area

### DIFF
--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -32,22 +32,22 @@ export default ({ data }) => (
           >
             {node.frontmatter.title}{" "}
           </h3>
-          <h5
-            css={css`
-              color: #bbb;
-            `}
-          >
-            — {node.frontmatter.date}
-          </h5>
-
-          <p
-            css={css`
-              margin-bottom: 20px;
-            `}
-          >
-            {node.excerpt}
-          </p>
         </Link>
+        <h5
+          css={css`
+            color: #bbb;
+          `}
+        >
+          — {node.frontmatter.date}
+        </h5>
+
+        <p
+          css={css`
+            margin-bottom: 20px;
+          `}
+        >
+          {node.excerpt}
+        </p>
       </div>
     ))}
   </Layout>


### PR DESCRIPTION
Previously it was wrapped around the whole post preview block, now it only wraps around the post title header. 